### PR TITLE
Updating README and custom.py and adding mock credentials.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ AutoFR is a verbal free recall experiment that incorporates automatic speech-to-
 # Installing autoFR
 + Install [Docker](https://www.docker.com/) and [Google Chrome](https://www.google.com/chrome/browser/desktop/index.html)
 + Clone this repo: `git clone https://github.com/ContextLab/autoFR.git`
-+ Set up Google Cloud Speech following [these](http://cdl-quail.readthedocs.io/en/latest/tutorial/speech_decoding.html#setting-up-the-google-speech-api) instructions. Once you have a JSON formatted API keyfile downloaded, put in in the exp/autoFR/google-credentials folder, renaming it credentials.json.
++ Set up Google Cloud Speech following [these](http://cdl-quail.readthedocs.io/en/latest/tutorial/speech_decoding.html#setting-up-the-google-speech-api) instructions. (see `exp/autoFR/google-credentials/credentials.json` for an empty template). Once you have a JSON formatted API keyfile downloaded, replace the empty template with it, renaming this new JSON to `credentials.json`.
++ Insert your `aws_access_key_id` and `aws_secret_access_key` in the file `exp/.psyturkconfig`. This file appears hidden, so you may have to change your file explorer's visibility settings to find and open it. You may also add your `psiturk_access_key_id` and `psiturk_secret_access_id` to this file, though it is not necessary to run the experiment locally.
++ Create an empty folder called `exp/audio`, which is where the participant data will be stored.
 
 # Running autoFR
 + Run docker

--- a/exp/autoFR/custom.py
+++ b/exp/autoFR/custom.py
@@ -33,8 +33,8 @@ custom_code = Blueprint('custom_code', __name__, template_folder='templates', st
 # Google speech
 import base64
 import json
-from google.cloud import speech
-client = speech.Client()
+from google.cloud import speech_v1
+client = speech_v1.SpeechClient()
 
 # load in speech context
 with open('static/files/speech-context.csv', 'rb') as csvfile:

--- a/exp/autoFR/google-credentials/credentials.json
+++ b/exp/autoFR/google-credentials/credentials.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "",
+  "private_key_id": "",
+  "private_key": "",
+  "client_email": "",
+  "client_id": "",
+  "auth_uri": "",
+  "token_uri": "",
+  "auth_provider_x509_cert_url": "",
+  "client_x509_cert_url": ""
+}


### PR DESCRIPTION
- Updated the `README` to make the installation process more clear, as well as to recommend the creation of an `audio` folder. I'm not very familiar with Docker, so perhaps there's a way in the Dockerfile to create this `audio` subfolder. Otherwise, if there isn't an existing `audio` folder or one doesn't know to create it, they'll receive the following error in the console while running the experiment (at least I did):

```
mkdir: cannot create directory 'audio/debugwUyfe:debugjOKhy': No such file or directory
Error with saving audio.
Error decoding audio.
Traceback (most recent call last):
  File "/psiturk/autofr/custom.py", line 80, in decode_experiment
    speech_context=speech_context)
  File "/usr/local/lib/python2.7/dist-packages/quail/decode_speech.py", line 203, in decode_speech
    listdirectory = os.listdir(path)
OSError: [Errno 2] No such file or directory: 'audio/debugwUyfe:debugjOKhy/'
```

- Added a mock version of `credentials.json` to help know what type of file to create. It can otherwise be confusing going through Google Cloud's directions and knowing which file to look for. (this is probably the least important suggested change).

- Change two lines in `custom.py` so that there are no errors running the experiment. Currently, one (or at least I) runs into the following error while trying to run psiturk: 'gunicorn.errors.HaltServer: <HaltServer 'Worker failed to boot.' 3>'  (based on https://github.com/googleapis/google-cloud-python/issues/4787#issuecomment-360347124).